### PR TITLE
AndroidCodegenTarget added.

### DIFF
--- a/SwipeListView/FortySevenDeg.SwipeListView.csproj
+++ b/SwipeListView/FortySevenDeg.SwipeListView.csproj
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
Newer versions of Xamarin.Android have shipped with a new way of generated android callable wrapper code that's a bit higher performance than the current default.  By setting the AndroidCodegenTarget MSBuild property to `XAJavaInterop1` you can opt into this newer generator.  Please consider merging this and releasing an update to your bindings.  

Thanks!